### PR TITLE
infra: implement cascading workflow pipeline

### DIFF
--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -5,9 +5,7 @@
 name: Deploy Next.js site to Pages
 
 on:
-  # Runs on pushes targeting the default branch
-  push:
-    branches: ["master"]
+
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,16 @@
 name: Release
 
 on:
-  push:
-    branches:
-      - master
+  workflow_run:
+    workflows: ["CI"]
+    branches: ["master"]
+    types: 
+      - completed
   workflow_dispatch:
 
 jobs:
   release:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Refactors the CI/CD pipeline to be strictly cascading: CI -> Release -> Deploy. \n\n- 'Release' now waits for 'CI' success (using 'on: workflow_run').\n- 'Deploy' no longer runs on push, strictly triggered by 'Release'.