### PR TITLE
fix: robust deploy condition check

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,7 +73,7 @@ jobs:
   deploy:
     name: Deploy to GitHub Pages
     needs: release
-    if: needs.release.outputs.new_release_published == 'true' || github.event_name == 'workflow_dispatch'
+    if: ${{ needs.release.outputs.new_release_published == 'true' || needs.release.outputs.new_release_published == true || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     environment:
       name: github-pages


### PR DESCRIPTION
Wraps the deployment condition in an expression interpolation `${{ ... }}` to ensure robust evaluation of both string and boolean types for `new_release_published`. This fixes skipped deployments.