### PR TITLE
fix: simplified deployment trigger

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,7 +73,7 @@ jobs:
   deploy:
     name: Deploy to GitHub Pages
     needs: release
-    if: ${{ needs.release.outputs.new_release_published == 'true' || needs.release.outputs.new_release_published == true || github.event_name == 'workflow_dispatch' }}
+
     runs-on: ubuntu-latest
     environment:
       name: github-pages


### PR DESCRIPTION
Removes the conditional check from the release job as requested. The deployment will now always proceed if the release job completes reliably, simplifying the logic.