### PR TITLE
fix: manual env creation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,10 +94,9 @@ jobs:
         run: yarn install --frozen-lockfile --ignore-scripts
 
       - name: Create .env file
-        uses: ozaytsev86/create-env-file-action@v1
-        with:
-          ENV_NEXT_PUBLIC_POSTHOG_KEY: ${{ secrets.POSTHOG_KEY }}
-          ENV_NEXT_PUBLIC_POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
+        run: |
+          echo "NEXT_PUBLIC_POSTHOG_KEY=${{ secrets.POSTHOG_KEY }}" >> .env
+          echo "NEXT_PUBLIC_POSTHOG_HOST=${{ secrets.POSTHOG_HOST }}" >> .env
 
       - name: Configure Pages via Next.js
         uses: actions/configure-pages@v4


### PR DESCRIPTION
Replaces the `ozaytsev86/create-env-file-action` with a manual shell script to create the `.env` file. The action was failing due to improper input handling. Using `echo` with GitHub Secrets is a standard and secure alternative.