### PR TITLE
fix: capture semantic-release outputs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,9 +65,9 @@ jobs:
 
       - name: Semantic Release
         id: semantic
+        uses: cycjimmy/semantic-release-action@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npx semantic-release
 
   # 3. Deployment Stage
   deploy:


### PR DESCRIPTION
Ensures deploy job checks out the correct version by using cycjimmy/semantic-release-action to properly capture outputs.