### PR TITLE
feat: add GA4 custom events for command menu

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/components/command-menu.tsx
+++ b/src/components/command-menu.tsx
@@ -31,7 +31,18 @@ export const CommandMenu = ({ links }: Props) => {
     const down = (e: KeyboardEvent) => {
       if (e.key === "j" && (e.metaKey || e.ctrlKey)) {
         e.preventDefault();
-        setOpen((open) => !open);
+        setOpen((open) => {
+          const newOpen = !open;
+
+          if (!open && newOpen) {
+            // Track opening the command menu via keyboard shortcut
+            sendGAEvent("event", "open_command_menu", {
+              source: "hotkey_cmd_j",
+            });
+          }
+
+          return newOpen;
+        });
       }
     };
 
@@ -50,7 +61,18 @@ export const CommandMenu = ({ links }: Props) => {
   }, [open, shouldPrint]);
 
   function handleCommandButtonClick() {
-    setOpen((open) => !open);
+    setOpen((open) => {
+      const newOpen = !open;
+
+      if (!open && newOpen) {
+        // Track opening the command menu via button click
+        sendGAEvent("event", "open_command_menu", {
+          source: "click_command_menu_button",
+        });
+      }
+
+      return newOpen;
+    });
   }
 
   return (
@@ -79,7 +101,9 @@ export const CommandMenu = ({ links }: Props) => {
               value="print"
               onSelect={() => {
                 setShouldPrint(true);
-                sendGAEvent({ event: "print", source: "command_menu" });
+                sendGAEvent("event", "print", {
+                  source: "click_print",
+                });
                 setOpen(false);
               }}
             >
@@ -95,8 +119,7 @@ export const CommandMenu = ({ links }: Props) => {
                 onSelect={() => {
                   setOpen(false);
                   // Track command menu link clicked
-                  sendGAEvent({
-                    event: "click_link",
+                  sendGAEvent("event", "click_link", {
                     link_url: url,
                     link_text: title,
                   });


### PR DESCRIPTION
## Summary
- Add GA4 custom events for opening the command menu (hotkey and button).
- Track print action and command menu link clicks with structured event parameters.
- Update Next.js route types import path in next-env.d.ts.

## Test plan
- Open command menu via Cmd/Ctrl+J and confirm 'open_command_menu' event with 'source=hotkey_cmd_j' in GA4 DebugView.
- Open command menu via the floating button and confirm 'open_command_menu' with 'source=click_command_menu_button'.
- Click 'Print' from the command menu and confirm 'print' event with 'source=click_print'.
- Click any command menu link and confirm 'click_link' event with 'link_text' and 'link_url' parameters.